### PR TITLE
[refactor] command.rs を複数ファイルへ分割

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -87,33 +87,7 @@ async fn find(db: Synced<impl MeigenDatabase>, opt: FindOptions<'_>) -> Result<S
 
 mod search;
 pub use search::author::search_author;
-
-pub async fn search_content(
-    db: Synced<impl MeigenDatabase>,
-    content: &str,
-    show_count: Option<u8>,
-    page: Option<u32>,
-) -> Result<String> {
-    let page = page.unwrap_or(0);
-    let (show_count, clamp_msg) = option!({
-        value: show_count,
-        default: 5,
-        min: 1,
-        max: 10
-    });
-
-    find(
-        db,
-        FindOptions {
-            author: None,
-            content: Some(content),
-            offset: page * (show_count as u32),
-            limit: show_count,
-        },
-    )
-    .await
-    .edit(|x| x.insert_str(0, clamp_msg))
-}
+pub use search::content::search_content;
 
 pub async fn list(
     db: Synced<impl MeigenDatabase>,

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,7 +3,7 @@ use {
         db::{FindOptions, MeigenDatabase},
         Synced,
     },
-    anyhow::{Context, Result},
+    anyhow::Result,
 };
 
 const LIST_LENGTH_LIMIT: usize = 400;
@@ -94,16 +94,5 @@ pub use list::list;
 mod delete;
 pub use delete::delete;
 
-pub async fn id(db: Synced<impl MeigenDatabase>, id: u32) -> Result<String> {
-    let meigen = db
-        .read()
-        .await
-        .load(id)
-        .await
-        .context("failed to get meigen")?;
-
-    Ok(match meigen {
-        Some(m) => format!("{}", m),
-        None => "そのIDを持つ名言はありません".into(),
-    })
-}
+mod id;
+pub use id::id;

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,7 +1,6 @@
 use {
     crate::{
         db::{FindOptions, MeigenDatabase},
-        util::IteratorEditExt,
         Synced,
     },
     anyhow::{Context, Result},
@@ -89,31 +88,8 @@ mod search;
 pub use search::author::search_author;
 pub use search::content::search_content;
 
-pub async fn list(
-    db: Synced<impl MeigenDatabase>,
-    show_count: Option<u8>,
-    page: Option<u32>,
-) -> Result<String> {
-    let page = page.unwrap_or(0);
-    let (show_count, clamp_msg) = option!({
-        value: show_count,
-        default: 5,
-        min: 1,
-        max: 10
-    });
-
-    find(
-        db,
-        FindOptions {
-            author: None,
-            content: None,
-            offset: (show_count as u32) * page,
-            limit: show_count,
-        },
-    )
-    .await
-    .edit(|x| x.insert_str(0, clamp_msg))
-}
+mod list;
+pub use list::list;
 
 const KAWAEMON_DISCORD_USER_ID: u64 = 391857452360007680;
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -73,23 +73,8 @@ macro_rules! option {
     }};
 }
 
-pub async fn help() -> Result<String> {
-    const HELP_TEXT: &str = "```asciidoc
-= meigen-bot-rust =
-g!meigen [subcommand] [args...]
-= subcommands =
-    help                                    :: この文を出します
-    make [作者] [名言]                       :: 名言を登録します
-    list [表示数=5] [ページ=1]                :: 名言をリスト表示します
-    id [名言ID]                             :: 指定されたIDの名言を表示します
-    search [検索内容] [表示数=5] [ページ=1]    :: 名言を検索します(g!meigen searchでヘルプを表示します)
-    random [表示数=1]                       :: ランダムに名言を出します
-    status                                 :: 現在登録されてる名言の数を出します
-    delete [名言ID]                         :: 指定されたIDの名言を削除します かわえもんにしか使えません
-```";
-
-    Ok(HELP_TEXT.into())
-}
+mod help;
+pub use help::help;
 
 pub async fn status(db: Synced<impl MeigenDatabase>) -> Result<String> {
     let count = db

--- a/src/command.rs
+++ b/src/command.rs
@@ -91,31 +91,8 @@ pub use search::content::search_content;
 mod list;
 pub use list::list;
 
-const KAWAEMON_DISCORD_USER_ID: u64 = 391857452360007680;
-
-pub async fn delete(
-    db: Synced<impl MeigenDatabase>,
-    meigen_id: u32,
-    user_id: u64,
-) -> Result<String> {
-    if user_id != KAWAEMON_DISCORD_USER_ID {
-        return Ok("このコマンドはかわえもんにしか実行できません".into());
-    }
-
-    let deleted = db
-        .write()
-        .await
-        .delete(meigen_id)
-        .await
-        .context("failed to delete meigen")?;
-
-    Ok(if deleted {
-        "削除しました"
-    } else {
-        "そのIDを持つ名言は存在しません"
-    }
-    .into())
-}
+mod delete;
+pub use delete::delete;
 
 pub async fn id(db: Synced<impl MeigenDatabase>, id: u32) -> Result<String> {
     let meigen = db

--- a/src/command.rs
+++ b/src/command.rs
@@ -76,21 +76,8 @@ macro_rules! option {
 mod help;
 pub use help::help;
 
-pub async fn status(db: Synced<impl MeigenDatabase>) -> Result<String> {
-    let count = db
-        .read()
-        .await
-        .count()
-        .await
-        .context("Failed to fetch meigen count")?;
-
-    Ok(format!(
-        "```yaml
-total_count: {}
-```",
-        count
-    ))
-}
+mod status;
+pub use status::status;
 
 pub async fn random(db: Synced<impl MeigenDatabase>, count: Option<u8>) -> Result<String> {
     let (count, clamp_msg) = option!({

--- a/src/command.rs
+++ b/src/command.rs
@@ -7,7 +7,6 @@ use {
     anyhow::{Context, Result},
 };
 
-const MEIGEN_LENGTH_LIMIT: usize = 300;
 const LIST_LENGTH_LIMIT: usize = 400;
 
 trait IterExt {
@@ -79,20 +78,8 @@ pub use status::status;
 mod random;
 pub use random::random;
 
-pub async fn make(db: Synced<impl MeigenDatabase>, author: &str, content: &str) -> Result<String> {
-    let strip = |s: &str| s.replace("`", "");
-
-    let author = strip(author);
-    let content = strip(content);
-
-    if author.chars().count() + content.chars().count() > MEIGEN_LENGTH_LIMIT {
-        return Ok("名言が長すぎます。もっと短くしてください。".into());
-    }
-
-    let meigen = db.write().await.save(author, content).await?;
-
-    Ok(format!("{}", meigen))
-}
+mod make;
+pub use make::make;
 
 async fn find(db: Synced<impl MeigenDatabase>, opt: FindOptions<'_>) -> Result<String> {
     Ok(db.read().await.find(opt).await?.into_iter().fold_list())

--- a/src/command.rs
+++ b/src/command.rs
@@ -85,32 +85,8 @@ async fn find(db: Synced<impl MeigenDatabase>, opt: FindOptions<'_>) -> Result<S
     Ok(db.read().await.find(opt).await?.into_iter().fold_list())
 }
 
-pub async fn search_author(
-    db: Synced<impl MeigenDatabase>,
-    author: &str,
-    show_count: Option<u8>,
-    page: Option<u32>,
-) -> Result<String> {
-    let page = page.unwrap_or(0);
-    let (show_count, clamp_msg) = option!({
-        value: show_count,
-        default: 5,
-        min: 1,
-        max: 10
-    });
-
-    find(
-        db,
-        FindOptions {
-            author: Some(author),
-            content: None,
-            offset: page * (show_count as u32),
-            limit: show_count,
-        },
-    )
-    .await
-    .edit(|x| x.insert_str(0, clamp_msg))
-}
+mod search;
+pub use search::author::search_author;
 
 pub async fn search_content(
     db: Synced<impl MeigenDatabase>,

--- a/src/command/delete.rs
+++ b/src/command/delete.rs
@@ -1,0 +1,30 @@
+use {
+    crate::{db::MeigenDatabase, Synced},
+    anyhow::{Context, Result},
+};
+
+const KAWAEMON_DISCORD_USER_ID: u64 = 391857452360007680;
+
+pub async fn delete(
+    db: Synced<impl MeigenDatabase>,
+    meigen_id: u32,
+    user_id: u64,
+) -> Result<String> {
+    if user_id != KAWAEMON_DISCORD_USER_ID {
+        return Ok("このコマンドはかわえもんにしか実行できません".into());
+    }
+
+    let deleted = db
+        .write()
+        .await
+        .delete(meigen_id)
+        .await
+        .context("failed to delete meigen")?;
+
+    Ok(if deleted {
+        "削除しました"
+    } else {
+        "そのIDを持つ名言は存在しません"
+    }
+    .into())
+}

--- a/src/command/help.rs
+++ b/src/command/help.rs
@@ -1,0 +1,19 @@
+use anyhow::Result;
+
+pub async fn help() -> Result<String> {
+    const HELP_TEXT: &str = "```asciidoc
+= meigen-bot-rust =
+g!meigen [subcommand] [args...]
+= subcommands =
+  help                                    :: この文を出します
+  make [作者] [名言]                       :: 名言を登録します
+  list [表示数=5] [ページ=1]                :: 名言をリスト表示します
+  id [名言ID]                             :: 指定されたIDの名言を表示します
+  search [検索内容] [表示数=5] [ページ=1]    :: 名言を検索します(g!meigen searchでヘルプを表示します)
+  random [表示数=1]                       :: ランダムに名言を出します
+  status                                 :: 現在登録されてる名言の数を出します
+  delete [名言ID]                         :: 指定されたIDの名言を削除します かわえもんにしか使えません
+```";
+
+    Ok(HELP_TEXT.into())
+}

--- a/src/command/id.rs
+++ b/src/command/id.rs
@@ -1,0 +1,18 @@
+use {
+    crate::{db::MeigenDatabase, Synced},
+    anyhow::{Context, Result},
+};
+
+pub async fn id(db: Synced<impl MeigenDatabase>, id: u32) -> Result<String> {
+    let meigen = db
+        .read()
+        .await
+        .load(id)
+        .await
+        .context("failed to get meigen")?;
+
+    Ok(match meigen {
+        Some(m) => format!("{}", m),
+        None => "そのIDを持つ名言はありません".into(),
+    })
+}

--- a/src/command/list.rs
+++ b/src/command/list.rs
@@ -1,0 +1,35 @@
+use {
+    crate::{
+        db::{FindOptions, MeigenDatabase},
+        util::IteratorEditExt,
+        Synced,
+    },
+    anyhow::Result,
+};
+
+pub async fn list(
+    db: Synced<impl MeigenDatabase>,
+    show_count: Option<u8>,
+    page: Option<u32>,
+) -> Result<String> {
+    let page = page.unwrap_or(0);
+    let (show_count, clamp_msg) = option!({
+        value: show_count,
+        default: 5,
+        min: 1,
+        max: 10
+    });
+
+    use super::find;
+    find(
+        db,
+        FindOptions {
+            author: None,
+            content: None,
+            offset: (show_count as u32) * page,
+            limit: show_count,
+        },
+    )
+    .await
+    .edit(|x| x.insert_str(0, clamp_msg))
+}

--- a/src/command/make.rs
+++ b/src/command/make.rs
@@ -1,0 +1,21 @@
+use {
+    crate::{db::MeigenDatabase, Synced},
+    anyhow::Result,
+};
+
+const MEIGEN_LENGTH_LIMIT: usize = 300;
+
+pub async fn make(db: Synced<impl MeigenDatabase>, author: &str, content: &str) -> Result<String> {
+    let strip = |s: &str| s.replace("`", "");
+
+    let author = strip(author);
+    let content = strip(content);
+
+    if author.chars().count() + content.chars().count() > MEIGEN_LENGTH_LIMIT {
+        return Ok("名言が長すぎます。もっと短くしてください。".into());
+    }
+
+    let meigen = db.write().await.save(author, content).await?;
+
+    Ok(format!("{}", meigen))
+}

--- a/src/command/random.rs
+++ b/src/command/random.rs
@@ -1,0 +1,46 @@
+use {
+    crate::{db::MeigenDatabase, model::Meigen, Synced},
+    anyhow::Result,
+    rand::{rngs::StdRng, Rng, SeedableRng},
+    std::{future::Future, pin::Pin},
+};
+
+pub async fn random(db: Synced<impl MeigenDatabase>, count: Option<u8>) -> Result<String> {
+    let (count, clamp_msg) = option!({
+        value: count,
+        default: 1,
+        min: 1,
+        max: 5,
+    });
+
+    fn get_random<'a>(
+        db: &'a Synced<impl MeigenDatabase>,
+        max: u32,
+    ) -> Pin<Box<dyn Future<Output = Result<Meigen>> + Send + 'a>> {
+        Box::pin(async move {
+            let pos = StdRng::from_rng(&mut rand::thread_rng())
+                .unwrap()
+                .gen_range(1..=max);
+
+            match db.read().await.load(pos).await? {
+                Some(e) => Ok(e),
+                None => get_random(db, max).await,
+            }
+        })
+    }
+
+    let mut meigens = Vec::with_capacity(count as _);
+    let max = db.read().await.get_current_id().await?;
+
+    for _ in 0..count {
+        meigens.push(get_random(&db, max).await?);
+    }
+
+    meigens.sort_by_key(|x| x.id);
+
+    use super::IterExt;
+    let mut msg = meigens.into_iter().fold_list();
+    msg.insert_str(0, clamp_msg);
+
+    Ok(msg)
+}

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -1,0 +1,1 @@
+pub mod author;

--- a/src/command/search.rs
+++ b/src/command/search.rs
@@ -1,1 +1,2 @@
 pub mod author;
+pub mod content;

--- a/src/command/search/author.rs
+++ b/src/command/search/author.rs
@@ -1,0 +1,36 @@
+use {
+    crate::{
+        db::{FindOptions, MeigenDatabase},
+        util::IteratorEditExt,
+        Synced,
+    },
+    anyhow::Result,
+};
+
+pub async fn search_author(
+    db: Synced<impl MeigenDatabase>,
+    author: &str,
+    show_count: Option<u8>,
+    page: Option<u32>,
+) -> Result<String> {
+    let page = page.unwrap_or(0);
+    let (show_count, clamp_msg) = option!({
+        value: show_count,
+        default: 5,
+        min: 1,
+        max: 10
+    });
+
+    use super::super::find;
+    find(
+        db,
+        FindOptions {
+            author: Some(author),
+            content: None,
+            offset: page * (show_count as u32),
+            limit: show_count,
+        },
+    )
+    .await
+    .edit(|x| x.insert_str(0, clamp_msg))
+}

--- a/src/command/search/content.rs
+++ b/src/command/search/content.rs
@@ -1,0 +1,36 @@
+use {
+    crate::{
+        db::{FindOptions, MeigenDatabase},
+        util::IteratorEditExt,
+        Synced,
+    },
+    anyhow::Result,
+};
+
+pub async fn search_content(
+    db: Synced<impl MeigenDatabase>,
+    content: &str,
+    show_count: Option<u8>,
+    page: Option<u32>,
+) -> Result<String> {
+    let page = page.unwrap_or(0);
+    let (show_count, clamp_msg) = option!({
+        value: show_count,
+        default: 5,
+        min: 1,
+        max: 10
+    });
+
+    use super::super::find;
+    find(
+        db,
+        FindOptions {
+            author: None,
+            content: Some(content),
+            offset: page * (show_count as u32),
+            limit: show_count,
+        },
+    )
+    .await
+    .edit(|x| x.insert_str(0, clamp_msg))
+}

--- a/src/command/status.rs
+++ b/src/command/status.rs
@@ -1,0 +1,20 @@
+use {
+    crate::{db::MeigenDatabase, Synced},
+    anyhow::{Context, Result},
+};
+
+pub async fn status(db: Synced<impl MeigenDatabase>) -> Result<String> {
+    let count = db
+        .read()
+        .await
+        .count()
+        .await
+        .context("Failed to fetch meigen count")?;
+
+    Ok(format!(
+        "```yaml
+total_count: {}
+```",
+        count
+    ))
+}


### PR DESCRIPTION
他モジュールと違って `mod.rs` は使っていません. 使ったほうが好ましい場合はお知らせください.
