### PR TITLE
dep: add 'small_rng' feature flag for 'rand' crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ anyhow = "1"
 async-trait = "0.1"
 dotenv = "0.15"
 tokio = { version = "1", features = ["full"] }
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 serde = { version = "1", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = "0.2"


### PR DESCRIPTION
## 内容
`Cargo.toml` の `dependencies` セクション内の `rand` に，"`small_rng`" `feature` フラグを追加しました．
なにかの間違いな気がしているので，なにかの間違いだったら教えてほしいです．

## 動機
以下のエラーでビルドができなかったので追加しました．

```rust
$ rustc --version -v
rustc 1.56.0 (09c42c458 2021-10-18)
binary: rustc
commit-hash: 09c42c45858d5f3aedfa670698275303a3d19afa
commit-date: 2021-10-18
host: x86_64-unknown-linux-gnu
release: 1.56.0
LLVM version: 13.0.0

$ cargo build
(snip)
error[E0432]: unresolved import `rand::prelude::SmallRng`
 --> src/command.rs:2:12
  |
2 | use rand::{prelude::SmallRng, Rng, SeedableRng};
  |            ^^^^^^^^^^^^^^^^^ no `SmallRng` in `prelude`
```

変更内容が変更内容なので一応これだけで PR を切ってみました．

## 参考
https://docs.rs/rand/0.8.4/rand/rngs/struct.SmallRng.html
